### PR TITLE
Update .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -17,9 +17,12 @@ pull_request_rules:
   - name: Automatically merge Dependabot PRs
     conditions:
       - or:
-        - author = dependabot[bot]
-        - title ~= chore\(deps
-        - title ~= Change version to
+        - and:
+          - author = dependabot[bot]
+          - title ~= ^chore\(deps\). bump [^\s]+ from ([\d]+)\..+ to \1\.
+        - and:
+          - author = sircharlo
+          - title ~= Change version to
     actions:
       update:
       merge:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -19,7 +19,7 @@ pull_request_rules:
       - or:
         - and:
           - author = dependabot[bot]
-          - title ~= ^chore\(deps\). bump [^\s]+ from ([\d]+)\..+ to \1\.
+          - title ~= ^chore\(deps(?:-dev)*\). bump [^\s]+ from ([\d]+)\..+ to \1\.
         - and:
           - author = github-actions[bot]
           - title ~= Change version to

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -21,7 +21,7 @@ pull_request_rules:
           - author = dependabot[bot]
           - title ~= ^chore\(deps\). bump [^\s]+ from ([\d]+)\..+ to \1\.
         - and:
-          - author = sircharlo
+          - author = github-actions[bot]
           - title ~= Change version to
     actions:
       update:


### PR DESCRIPTION
Fix security issues:

1. Currently, any PR from any author containing the specified title will automatically be merged, potentially merging a PR from a malicious user.
2. Currently, any PR from dependabot will get merged, including major version updates. Major version updates are major, because they have breaking changes and should therefore always be manually verified and tested.

With this fix PRs will only get merged automatically if:

1. Dependabot creates a PR for a non-major dependency update
2. Github Actions creates a PR to change the version